### PR TITLE
chore(big_bot): Comment out big bot arm opcontrol

### DIFF
--- a/big_bot/src/main.c
+++ b/big_bot/src/main.c
@@ -64,7 +64,7 @@ void opcontrol() {
 		conveyor_opcontrol(E_CONTROLLER_DIGITAL_L2, E_CONTROLLER_DIGITAL_A);
 		drivetrain_opcontrol(E_CONTROLLER_ANALOG_LEFT_Y,
 		                     E_CONTROLLER_ANALOG_RIGHT_Y);
-		arm_opcontrol(E_CONTROLLER_DIGITAL_UP, E_CONTROLLER_DIGITAL_DOWN);
+		// arm_opcontrol(E_CONTROLLER_DIGITAL_UP, E_CONTROLLER_DIGITAL_DOWN);
 		delay(20); // Run for 20 ms then update
 	}
 }


### PR DESCRIPTION
Arm isn't being used right now, and its ports overlap with other motors. Comment the arm opcontrol function to prevent the motors from constantly being told not to run.